### PR TITLE
docker: Install git before requiring it when installing Python dependencies.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ ARG VERSION=0.1.5
 
 RUN useradd -ms /bin/bash dans
 
+RUN apt-get update
+RUN apt-get install -y git
+
 USER dans
 WORKDIR /home/dans
 ENV PYTHONPATH=/home/dans/packaging-service/src


### PR DESCRIPTION
Building the Docker container fails with:
```
STEP 10/12: RUN mkdir -p ${BASE_DIR} &&     pip install --no-cache-dir *.whl && rm -rf *.whl &&     tar xf packaging_service-${VERSION}.tar.gz -C ${BASE_DIR} --strip-components 1
Defaulting to user installation because normal site-packages is not writeable
Processing ./packaging_service-0.1.5-py3-none-any.whl
Collecting sword2@ git+https://github.com/ekoi/python-client-sword2
  Cloning https://github.com/ekoi/python-client-sword2 to /tmp/pip-install-5j75gdvb/sword2_7120d07a181841a3a7ad873ce1733880
  ERROR: Error [Errno 2] No such file or directory: 'git' while executing command git version
ERROR: Cannot find command 'git' - do you have 'git' installed and in your PATH?
```

This patch fixes that by installing `git` in the container.